### PR TITLE
BF: Remove residual pkg_resources dependency

### DIFF
--- a/hlsvdpropy/__init__.py
+++ b/hlsvdpropy/__init__.py
@@ -15,23 +15,14 @@ Dependencies:
     
 """      
 try:
-    import importlib.metadata
+    from importlib.metadata import version
     version_method = 'importlib'
-except:
+    __version__ = version('hlsvdpropy')
+except ImportError:
     # 3rd party imports
     import pkg_resources
     version_method = 'pkg_resources'
-
-from importlib.metadata import version
-
-# 3rd party imports
-import pkg_resources
+    __version__ = pkg_resources.get_distribution('hlsvdpropy').version
 
 # This removes a useless layer of naming indirection.
 from hlsvdpropy.hlsvd import *
-
-if version_method == 'importlib':
-    __version__ = version('hlsvdpropy')
-else:
-    __version__ = pkg_resources.get_distribution('hlsvdpropy').version
-


### PR DESCRIPTION
Hi Brian, 

Your implementation of my proposed fix left a residual `pkg_resources` dependency here: https://github.com/wtclarke/hlsvdpropy/compare/master...BF-Residual-pkg_resources-dependency#diff-e8046ad1e77219f8f7bfe55dc25b2e6ffbac24429e7d6f768a10a5b45f9b8cc1L28

This should remove it and solve the upcoming problems in python 3.12 (where it is finally removed).